### PR TITLE
mt.go: fixup call to humanize, IBytes produces a human readable repre…

### DIFF
--- a/mt.go
+++ b/mt.go
@@ -469,7 +469,7 @@ func createHeader(fn string) []string {
 	if err != nil {
 		fmt.Println(err)
 	}
-	fsize := fmt.Sprintf("File Size: %s", humanize.Bytes(uint64(stat.Size())))
+	fsize := fmt.Sprintf("File Size: %s", humanize.IBytes(uint64(stat.Size())))
 	fname = fmt.Sprintf("File Name: %s", fname)
 
 	gen, err := screengen.NewGenerator(fn)


### PR DESCRIPTION
fixup call to humanize, IBytes produces a human readable representation of an IEC size, which is what we want