### PR TITLE
Throw error when duration is less than interval

### DIFF
--- a/mt.go
+++ b/mt.go
@@ -126,7 +126,6 @@ func GenerateScreenshots(fn string) []image.Image {
 		if durationSec < intervalSec {
 			log.Fatalf("Specified interval is longer than video duration, " +
 				"use smaller interval or set numcaps instead.")
-			os.Exit(1)
 		}
 		numcaps = int(durationSec / intervalSec)
 		log.Debugf("interval option set, numcaps are set to %d", numcaps)

--- a/mt.go
+++ b/mt.go
@@ -121,7 +121,14 @@ func GenerateScreenshots(fn string) []image.Image {
 
 	numcaps = viper.GetInt("numcaps")
 	if viper.GetInt("interval") > 0 {
-		numcaps = int((duration / 1000) / int64(viper.GetInt("interval")))
+		var durationSec = duration / 1000
+		var intervalSec = int64(viper.GetInt("interval"))
+		if durationSec < intervalSec {
+			log.Fatalf("Specified interval is longer than video duration, " +
+				"use smaller interval or set numcaps instead.")
+			os.Exit(1)
+		}
+		numcaps = int(durationSec / intervalSec)
 		log.Debugf("interval option set, numcaps are set to %d", numcaps)
 		viper.Set("columns", int(math.Sqrt(float64(numcaps))))
 	}


### PR DESCRIPTION
When the user specifies an interval greater than the duration of the video, the application will exit with code 1 after logging: "Specified interval is longer than video duration, use smaller interval or set numcaps instead."