### PR TITLE
Adding releases (binaries) to Github Actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,69 @@
+# unifying the coding style for different editors and IDEs => editorconfig.org
+
+; indicate this is the root of the project
+root = true
+
+###########################################################
+; common
+###########################################################
+
+[*]
+charset = utf-8
+end_of_line = LF
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+#max_line_length = 80
+
+
+###########################################################
+; make
+###########################################################
+
+[{Makefile, makefile, GNUmakefile}]
+indent_style = tab
+indent_size = 4
+
+
+###########################################################
+; markdown
+###########################################################
+
+[*.md *.mdown]
+trim_trailing_whitespace = false
+
+
+###########################################################
+; golang
+###########################################################
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+
+###########################################################
+; Yaml
+###########################################################
+
+[.yml]
+indent_style = space
+indent_size = 2
+
+
+###########################################################
+; shell
+###########################################################
+[{.bashrc, .bash_*, *.sh, .profile}]
+indent_style = tab
+indent_size = 4
+
+
+###########################################################
+; terraform
+###########################################################
+[*.{tf,tfvars}]
+indent_style = space
+indent_size = 4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,26 +28,25 @@ jobs:
      - uses: actions/setup-go@v3
        with:
         go-version: ${{ matrix.go }}
+
      - name: Retrieve GOOS
        id: goos
        run: |
          echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
 
      - name: Install dependencies
-       run: make buildffmpeg
+       run: make
        env:
           GOARCH: ${{ matrix.goarch }}
 
-     - uses: actions/upload-artifact@master
-       with:
-        name: mt_${{ env.GOOS }}_${{ matrix.goarch }}
-        path: mt
+     - name: Zip binary
+       id: zip
+       run: |
+         zip mt_${{ env.GOOS }}_${{ matrix.goarch }}.zip mt
 
-#     - name: Release
-#        uses: softprops/action-gh-release@v1
-#        if: startsWith(github.ref, 'refs/tags/')
-#        with:
-#          files: |
-#            release/cselo-linux-${{ steps.vars.outputs.tag }}.tgz
-#            release/cselo-mac-${{ steps.vars.outputs.tag }}.dmg
-#            release/cselo-win-${{ steps.vars.outputs.tag }}.zip
+     - name: Release
+       uses: softprops/action-gh-release@v1
+       if: startsWith(github.ref, 'refs/tags/')
+       with:
+          files: |
+            mt_${{ env.GOOS }}_${{ matrix.goarch }}.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,5 +54,4 @@ jobs:
        with:
           files: |
             mt_${{ env.GOOS }}_${{ matrix.goarch }}.tgz
-            ./dep/lib_${{ env.GOOS }}_${{ matrix.goarch }}.tgz
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,11 +42,11 @@ jobs:
      - name: Zip binary
        id: zip
        run: |
-         zip mt_${{ env.GOOS }}_${{ matrix.goarch }}.zip mt
+         tar zcf mt_${{ env.GOOS }}_${{ matrix.goarch }}.tgz mt
 
      - name: Release
        uses: softprops/action-gh-release@v1
        if: startsWith(github.ref, 'refs/tags/')
        with:
           files: |
-            mt_${{ env.GOOS }}_${{ matrix.goarch }}.zip
+            mt_${{ env.GOOS }}_${{ matrix.goarch }}.tgz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [ "master" ]
+    #branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
+    #branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,6 @@ jobs:
         go: [ '1.19.2' ]
         continue-on-error: [true]
     runs-on: ${{ matrix.os }}
-#    env:
-#      mgoarch:  ${{ matrix.goos }}
-#      mgoos:  ${{ matrix.goarch }}
 
     steps:
      - uses: actions/checkout@v3
@@ -57,4 +54,5 @@ jobs:
        with:
           files: |
             mt_${{ env.GOOS }}_${{ matrix.goarch }}.tgz
+            ./dep/lib_${{ env.GOOS }}_${{ matrix.goarch }}.tgz
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "master" ]
   pull_request:
@@ -12,8 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ]
-        goarch:  ['amd64'] # ['amd64', 'arm64'] # arm64 will not work as long Github does not provide arm runners
-        go: [ 'latest' ]
+        goarch:  ['amd64'] # ['amd64', 'arm64'] # arm64 will not work as long Github does not provide
+        go: [ '1.19.2' ]
         continue-on-error: [true]
 
     runs-on: ${{ matrix.os }}
@@ -41,3 +42,12 @@ jobs:
        with:
         name: mt_${{ env.GOOS }}_${{ matrix.goarch }}
         path: mt
+
+#     - name: Release
+#        uses: softprops/action-gh-release@v1
+#        if: startsWith(github.ref, 'refs/tags/')
+#        with:
+#          files: |
+#            release/cselo-linux-${{ steps.vars.outputs.tag }}.tgz
+#            release/cselo-mac-${{ steps.vars.outputs.tag }}.dmg
+#            release/cselo-win-${{ steps.vars.outputs.tag }}.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ]
-        goarch: ['amd64', 'arm64']
-        go: [ '1.18.3' ]
+        goarch:  ['amd64'] # ['amd64', 'arm64'] # arm64 will not work as long Github does not provide arm runners
+        go: [ 'latest' ]
         continue-on-error: [true]
 
     runs-on: ${{ matrix.os }}
@@ -40,6 +40,4 @@ jobs:
      - uses: actions/upload-artifact@master
        with:
         name: mt_${{ env.GOOS }}_${{ matrix.goarch }}
-        path: |
-          lib_ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}.zip
-
+        path: mt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,21 +16,13 @@ jobs:
         goarch:  ['amd64'] # ['amd64', 'arm64'] # arm64 will not work as long Github does not provide
         go: [ '1.19.2' ]
         continue-on-error: [true]
-
     runs-on: ${{ matrix.os }}
-    env:
-      mgoarch:  ${{ matrix.goos }}
-      mgoos:  ${{ matrix.goarch }}
+#    env:
+#      mgoarch:  ${{ matrix.goos }}
+#      mgoos:  ${{ matrix.goarch }}
 
     steps:
      - uses: actions/checkout@v3
-
-     - name: Cache ffmpeg libraries
-       uses: actions/cache@v3
-       with:
-        path: |
-          ./dep/ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}
-        key: ./dep/ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}
 
      - uses: actions/setup-go@v3
        with:
@@ -40,6 +32,14 @@ jobs:
        id: goos
        run: |
          echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
+
+     - name: Cache ffmpeg libraries
+       uses: actions/cache@v3
+       with:
+        path: |
+          ./dep/ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}
+        key: ./dep/ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}
+
 
      - name: build (Go && ffmpeg if needed)
        run: make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,13 @@ jobs:
     steps:
      - uses: actions/checkout@v3
 
+     - name: Cache ffmpeg libraries
+       uses: actions/cache@v3
+       with:
+        path: |
+          ./dep/ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}
+        key: ./dep/ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}
+
      - uses: actions/setup-go@v3
        with:
         go-version: ${{ matrix.go }}
@@ -34,7 +41,7 @@ jobs:
        run: |
          echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
 
-     - name: Install dependencies
+     - name: build (Go && ffmpeg if needed)
        run: make
        env:
           GOARCH: ${{ matrix.goarch }}
@@ -50,3 +57,4 @@ jobs:
        with:
           files: |
             mt_${{ env.GOOS }}_${{ matrix.goarch }}.tgz
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,8 @@ jobs:
        uses: actions/cache@v3
        with:
         path: |
-          ./dep/ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}
-        key: ./dep/ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}
+          dep/ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}
+        key: ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}
 
 
      - name: build (Go && ffmpeg if needed)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,21 +5,41 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
- 
-  workflow_dispatch:
 
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        goarch: ['amd64', 'arm64']
+        go: [ '1.18.3' ]
+        continue-on-error: [true]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    env:
+      mgoarch:  ${{ matrix.goos }}
+      mgoos:  ${{ matrix.goarch }}
 
     steps:
-    - uses: actions/checkout@v3
+     - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.16
-      
-    - name: Install dependencies
-      run: make
+     - uses: actions/setup-go@v3
+       with:
+        go-version: ${{ matrix.go }}
+     - name: Retrieve GOOS
+       id: goos
+       run: |
+         echo "GOOS=$(go env GOOS)" >> $GITHUB_ENV
+
+     - name: Install dependencies
+       run: make buildffmpeg
+       env:
+          GOARCH: ${{ matrix.goarch }}
+
+     - uses: actions/upload-artifact@master
+       with:
+        name: mt_${{ env.GOOS }}_${{ matrix.goarch }}
+        path: |
+          lib_ffmpeg_${{ env.GOOS }}_${{ matrix.goarch }}.zip
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
 mt
+dep
+dep/ffmpeg-*
+dep/ffmpeg_*/share
+dep/ffmpeg_*/include
+dep/ffmpeg_*/lib/pkgconfig*
+.vscode/
+.idea/
+.DS_Store/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 #target is to generate several bin files automatically
 ARCHES := linux_amd64 i686-w64-mingw32 x86_64-w64-mingw32 arm-linux-gnueabihf
 
-#FFMPEG_PKG = ffmpeg-5.1.2
 FFMPEG_PKG = ffmpeg-4.4
 FFMPEG_EXT = tar.bz2
 FFMPEG_SRC = http://ffmpeg.org/releases/$(FFMPEG_PKG).$(FFMPEG_EXT)
@@ -20,11 +19,8 @@ else
 endif
 
 all: ffmpeg build
-	echo $(VERSIONFLAGS)
-	echo $(FFMPEGTARGET)
 
 build:
-#	go build $(GOFLAGS)
 	PKG_CONFIG_LIBDIR=$(FFMPEGTARGET)/lib/pkgconfig/ LD_LIBRARY_PATH=$(FFMPEGTARGET)/lib/ go build $(GOFLAGS)
 
 buildffmpeg:
@@ -34,7 +30,7 @@ buildffmpeg:
 	cd $(PREFIX)/$(FFMPEG_PKG) && ./configure --disable-yasm --disable-programs --disable-doc --prefix=$(FFMPEGTARGET)
 	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG) --silent -j`nproc`
 	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG)  install --silent
-	zip -r $(PREFIX)/lib_ffmpeg_$(GOOS)_$(GOARCH) $(PREFIX)/ffmpeg_$(GOOS)_$(GOARCH)/lib/*
+	tar zcf -r $(PREFIX)/lib_ffmpeg_$(GOOS)_$(GOARCH).tgz $(PREFIX)/ffmpeg_$(GOOS)_$(GOARCH)/lib/*
 
 
 $(FFMPEGTARGET)/lib/libavcodec.a:

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ all: ffmpeg build
 	echo $(FFMPEGTARGET)
 
 build:
-	go build $(GOFLAGS)
-#	PKG_CONFIG_LIBDIR=$(FFMPEGTARGET)/lib/pkgconfig/ LD_LIBRARY_PATH=$(FFMPEGTARGET)/lib/ go build $(GOFLAGS)
+#	go build $(GOFLAGS)
+	PKG_CONFIG_LIBDIR=$(FFMPEGTARGET)/lib/pkgconfig/ LD_LIBRARY_PATH=$(FFMPEGTARGET)/lib/ go build $(GOFLAGS)
 
 buildffmpeg:
 	mkdir -p $(FFMPEGTARGET)

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,6 @@ buildffmpeg:
 	cd $(PREFIX)/$(FFMPEG_PKG) && ./configure --disable-yasm --disable-programs --disable-doc --prefix=$(FFMPEGTARGET)
 	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG) --silent -j`nproc`
 	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG)  install --silent
-	tar zcf $(PREFIX)/lib_ffmpeg_$(GOOS)_$(GOARCH).tgz $(PREFIX)/ffmpeg_$(GOOS)_$(GOARCH)/lib/*
-
 
 $(FFMPEGTARGET)/lib/libavcodec.a:
 	$(MAKE) buildffmpeg

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,64 @@
 #target is to generate several bin files automatically
 ARCHES := linux_amd64 i686-w64-mingw32 x86_64-w64-mingw32 arm-linux-gnueabihf
 
-FFMPEG_PKG = ffmpeg-4.4
+FFMPEG_PKG = ffmpeg-5.1.2
+#FFMPEG_PKG = ffmpeg-4.4
 FFMPEG_EXT = tar.bz2
 FFMPEG_SRC = http://ffmpeg.org/releases/$(FFMPEG_PKG).$(FFMPEG_EXT)
 
+GOARCH = $(shell go env GOARCH)
+GOOS = $(shell go env GOOS)
+PROJECTROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+PREFIX = $(PROJECTROOT)dep
+FFMPEGTARGET = $(PREFIX)/ffmpeg_$(GOOS)_$(GOARCH)
+
 ifeq ($(UNAME),Darwin)
-	GOFLAGS = --ldflags '-extldflags "-static -Wl,--allow-multiple-definition"'
+	GOFLAGS = -ldflags '-L "$(PREFIX)/ffmpeg_$(GOOS)_$(GOARCH)/lib/" -extldflags "-static -Wl,--allow-multiple-definition"'
 else
-	GOFLAGS =
+	GOFLAGS = -ldflags='-L "$(PREFIX)/ffmpeg_$(GOOS)_$(GOARCH)/lib/"'
 endif
 
-all: ffmpeg
-	PKG_CONFIG_LIBDIR=/tmp/ffmpeg/lib/pkgconfig/ LD_LIBRARY_PATH=/tmp/ffmpeg/lib/ go build $(GOFLAGS)
+all: ffmpeg build
+	echo $(FFMPEGTARGET)
 
-ffmpeg:
-	wget -P /tmp $(FFMPEG_SRC)
-	tar -xf /tmp/$(FFMPEG_PKG).$(FFMPEG_EXT) -C /tmp/
-	cd /tmp/$(FFMPEG_PKG) && ./configure --disable-yasm --disable-programs --disable-doc --prefix=/tmp/ffmpeg && make --silent -j`nproc` && make install --silent
+build:
+	go build $(GOFLAGS)
+#	PKG_CONFIG_LIBDIR=$(FFMPEGTARGET)/lib/pkgconfig/ LD_LIBRARY_PATH=$(FFMPEGTARGET)/lib/ go build $(GOFLAGS)
+
+buildffmpeg:
+	mkdir -p $(FFMPEGTARGET)
+	wget -P $(PREFIX) $(FFMPEG_SRC)
+	tar -xf $(PREFIX)/$(FFMPEG_PKG).$(FFMPEG_EXT) -C $(PREFIX)/
+	cd $(PREFIX)/$(FFMPEG_PKG) && ./configure --disable-yasm --disable-programs --disable-doc --prefix=$(FFMPEGTARGET)
+	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG) --silent -j`nproc`
+#;$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG) --silent -j`nproc`
+	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG)  install --silent
+	zip -r $(PREFIX)/lib_ffmpeg_$(GOOS)_$(GOARCH) $(PREFIX)/ffmpeg_$(GOOS)_$(GOARCH)/lib/*
+
+
+$(FFMPEGTARGET)/lib/libavcodec.a:
+	$(MAKE) buildffmpeg
+
+$(FFMPEGTARGET)/lib/libavformat.a:
+
+
+$(FFMPEGTARGET)/lib/libavutil.a:
+
+
+$(FFMPEGTARGET)/lib/libswresample.a:
+
+
+$(FFMPEGTARGET)/lib/libswscale.a:
+
+
+ffmpeg: $(FFMPEGTARGET)/lib/libavcodec.a $(FFMPEGTARGET)/lib/libavformat.a $(FFMPEGTARGET)/lib/libavutil.a $(FFMPEGTARGET)/lib/libswresample.a $(FFMPEGTARGET)/lib/libswscale.a
+
 
 clean:
-	rm /tmp/$(FFMPEG_PKG).$(FFMPEG_EXT)
-	rm -rf /tmp/$(FFMPEG_PKG)
+	rm -f $(PREFIX)/$(FFMPEG_PKG).$(FFMPEG_EXT)
+	rm -rf $(PREFIX)/$(FFMPEG_PKG)
+	rm -f mt
+
+wipe: clean
+	rm -rf dep
+

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ buildffmpeg:
 	cd $(PREFIX)/$(FFMPEG_PKG) && ./configure --disable-yasm --disable-programs --disable-doc --prefix=$(FFMPEGTARGET)
 	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG) --silent -j`nproc`
 	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG)  install --silent
-	tar zcf -r $(PREFIX)/lib_ffmpeg_$(GOOS)_$(GOARCH).tgz $(PREFIX)/ffmpeg_$(GOOS)_$(GOARCH)/lib/*
+	tar zcf $(PREFIX)/lib_ffmpeg_$(GOOS)_$(GOARCH).tgz $(PREFIX)/ffmpeg_$(GOOS)_$(GOARCH)/lib/*
 
 
 $(FFMPEGTARGET)/lib/libavcodec.a:

--- a/Makefile
+++ b/Makefile
@@ -40,16 +40,16 @@ $(FFMPEGTARGET)/lib/libavcodec.a:
 	$(MAKE) buildffmpeg
 
 $(FFMPEGTARGET)/lib/libavformat.a:
-
+	$(MAKE) buildffmpeg
 
 $(FFMPEGTARGET)/lib/libavutil.a:
-
+	$(MAKE) buildffmpeg
 
 $(FFMPEGTARGET)/lib/libswresample.a:
-
+	$(MAKE) buildffmpeg
 
 $(FFMPEGTARGET)/lib/libswscale.a:
-
+	$(MAKE) buildffmpeg
 
 ffmpeg: $(FFMPEGTARGET)/lib/libavcodec.a $(FFMPEGTARGET)/lib/libavformat.a $(FFMPEGTARGET)/lib/libavutil.a $(FFMPEGTARGET)/lib/libswresample.a $(FFMPEGTARGET)/lib/libswscale.a
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 #target is to generate several bin files automatically
 ARCHES := linux_amd64 i686-w64-mingw32 x86_64-w64-mingw32 arm-linux-gnueabihf
 
-FFMPEG_PKG = ffmpeg-5.1.2
-#FFMPEG_PKG = ffmpeg-4.4
+#FFMPEG_PKG = ffmpeg-5.1.2
+FFMPEG_PKG = ffmpeg-4.4
 FFMPEG_EXT = tar.bz2
 FFMPEG_SRC = http://ffmpeg.org/releases/$(FFMPEG_PKG).$(FFMPEG_EXT)
 

--- a/mt.go
+++ b/mt.go
@@ -27,11 +27,15 @@ import (
 	"gitlab.com/opennota/screengen"
 )
 
+var GitVersion = ""
+var FfmpegVersion = ""
+var BuildTimestamp = ""
+
 var blankPixels int
 var allPixels int
 var mpath string
 var fontBytes []byte
-var version string = "1.0.12"
+var version string = GitVersion + " (" + FfmpegVersion + ") built on " + BuildTimestamp
 var timestamps []string
 var numcaps int
 
@@ -387,7 +391,7 @@ func makeContactSheet(thumbs []image.Image, fn string) {
 
 		if viper.GetBool("vtt") {
 			_, imgName := filepath.Split(fn)
-			vttContent = fmt.Sprintf("%s\n%s.000 --> %s.000\n%s#xywh=%d,%d,%d,%d\n", vttContent, timestamps[idx], timestamps[idx+1], imgName, xPos, yPos + headerHeight, imgWidth, imgHeight)
+			vttContent = fmt.Sprintf("%s\n%s.000 --> %s.000\n%s#xywh=%d,%d,%d,%d\n", vttContent, timestamps[idx], timestamps[idx+1], imgName, xPos, yPos+headerHeight, imgWidth, imgHeight)
 		}
 
 	}


### PR DESCRIPTION
Hi! This change adds Github Releases, so that people can easily try the software.

I added a matrix build feature.

If triggered by an annotated tag push, then a release in Github will be created and the binaries will be uploaded there. (See https://github.com/wlbr/mt/releases ) 

FFMPEG will be downloaded and compiled only once and is reused from the Github build cache later, so the build time sinks significantly (to a tenth) for every build after the first.

To create a release you would need to add the lines 3 and 5 of the following:
```
git add .
git commit -m "New Feature"
git tag -a "v1.2.0" -m "New Feature v1.2.0"
git push
git push --tags
```

The Makefile now checks for the existence of the needed libraries and will download/build FFMPEG only if they are missing. This massively speeds up local build times, a MAKE run needs only 2 seconds on my machine now.

Unfortunately, Github does not offer ARM based runners currently. Therefore, a OSX M1 built or Linux Ampere (or something) does not work at the moment. If you connect private runners to your repo, then this should work out of the box. Once the CACHE of the FMMPEG libs is filled for each architecture, you could remove the private runner and do a Go crosscompile using the preexisting cache for the architecture specific FFMEG.

Probably it is possible to cross compile FFMPEG, so we would not need the ARM runners. Unfortunately, I have no idea how to do that.

I slightly modified the version info, so that the version is now filled from the Github tag. Additionally the ffmpeg version and a buildtimestamp is included.