### PR TITLE
Doubling the FFMPEG compile step to make it work with the second run.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ buildffmpeg:
 	tar -xf $(PREFIX)/$(FFMPEG_PKG).$(FFMPEG_EXT) -C $(PREFIX)/
 	cd $(PREFIX)/$(FFMPEG_PKG) && ./configure --disable-yasm --disable-programs --disable-doc --prefix=$(FFMPEGTARGET)
 	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG) --silent -j`nproc`
+	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG) --silent -j`nproc`
 	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG)  install --silent
 
 $(FFMPEGTARGET)/lib/libavcodec.a:


### PR DESCRIPTION
This is a problem with FFMPEG 4's Makefile.