### PR TITLE
Doubling the FFMPEG compile step.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ buildffmpeg:
 	wget -P $(PREFIX) $(FFMPEG_SRC)
 	tar -xf $(PREFIX)/$(FFMPEG_PKG).$(FFMPEG_EXT) -C $(PREFIX)/
 	cd $(PREFIX)/$(FFMPEG_PKG) && ./configure --disable-yasm --disable-programs --disable-doc --prefix=$(FFMPEGTARGET)
-	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG) --silent -j`nproc`
+	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG) --silent -j`nproc`;	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG) --silent -j`nproc`
 	$(MAKE) -C $(PREFIX)/$(FFMPEG_PKG)  install --silent
 
 $(FFMPEGTARGET)/lib/libavcodec.a:


### PR DESCRIPTION
Both compile in one line of the Makefile, so that the second run starts though the first might fail.